### PR TITLE
Add `.d.mts` file

### DIFF
--- a/lexer.d.mts
+++ b/lexer.d.mts
@@ -1,0 +1,1 @@
+export * from './lexer.js'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Lexes CommonJS modules, returning their named exports metadata",
   "main": "lexer.js",
   "exports": {
-    "import": "./dist/lexer.mjs",
+    "import": {
+      "types": "./lexer.d.mts",
+      "default": "./dist/lexer.mjs"
+    },
     "default": "./lexer.js"
   },
   "types": "lexer.d.ts",


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ See the reported problems [here](https://arethetypeswrong.github.io/?p=cjs-module-lexer%401.2.2). This PR only focuses on "🐛 Used fallback condition" because that's a TypeScript bug that can't be fixed before the usage gets fixed in popular packages. However, I think that the second problem (`🎭 Masquerading as CJS`) should also get fixed by this. Reexporting types like this isn't technically 100% correct (your implementation is duplicated between CJS and ESM and so the types should be too) but I think it's fairly OK to do it this way here since you don't export any nominal types or anything like that.