### PR TITLE
Parametrize WASM compilation process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,21 @@ WASM_EXTRA_LDFLAGS += -Wl,--export=__heap_base,--export=parseCJS,--export=sa
 WASM_EXTRA_LDFLAGS += -Wl,--export=e,--export=re,--export=es,--export=ee
 WASM_EXTRA_LDFLAGS += -Wl,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue
 
+.PHONY: optimize clean
+
 lib/lexer.wat: lib/lexer.wasm
 	$(WASM2WAT) lib/lexer.wasm -o lib/lexer.wat
 
-lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c
-	@mkdir -p lib
+lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c | lib/
 	$(WASM_CC) $(WASM_CFLAGS) $(WASM_EXTRA_CFLAGS) \
 		src/lexer.c -o lib/lexer.wasm \
 		$(WASM_LDFLAGS) $(WASM_EXTRA_LDFLAGS)
+
+lib/:
+	@mkdir -p $@
 
 optimize: lib/lexer.wasm
 	$(WASM_OPT) -Oz lib/lexer.wasm -o lib/lexer.wasm
 
 clean:
-	rm lib/*
+	$(RM) lib/*

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,23 @@
+# These flags depend on the system and may be overridden
+WASM_CC := ../wasi-sdk-12.0/bin/clang
+WASM_CFLAGS := --sysroot=../wasi-sdk-12.0/share/wasi-sysroot
+WASM_LDFLAGS := -nostartfiles
+
+# These are project-specific and are expected to be kept intact
+WASM_EXTRA_CFLAGS := -I include-wasm/ -Wno-logical-op-parentheses -Wno-parentheses -Oz
+WASM_EXTRA_LDFLAGS := -Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all
+WASM_EXTRA_LDFLAGS += -Wl,--export=__heap_base,--export=parseCJS,--export=sa
+WASM_EXTRA_LDFLAGS += -Wl,--export=e,--export=re,--export=es,--export=ee
+WASM_EXTRA_LDFLAGS += -Wl,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue
+
 lslib/lexer.wat: lib/lexer.wasm
 	../wabt/bin/wasm2wat lib/lexer.wasm -o lib/lexer.wat
 
 lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c
 	@mkdir -p lib
-	../wasi-sdk-12.0/bin/clang src/lexer.c -I include-wasm --sysroot=../wasi-sdk-12.0/share/wasi-sysroot -o lib/lexer.wasm -nostartfiles \
-	-Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all,--export=__heap_base,\
-	--export=parseCJS,--export=sa,--export=e,--export=re,--export=es,--export=ee,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue \
-	-Wno-logical-op-parentheses -Wno-parentheses \
-	-Oz
+	$(WASM_CC) $(WASM_CFLAGS) $(WASM_EXTRA_CFLAGS) \
+		src/lexer.c -o lib/lexer.wasm \
+		$(WASM_LDFLAGS) $(WASM_EXTRA_LDFLAGS)
 
 optimize: lib/lexer.wasm
 	../binaryen/bin/wasm-opt -Oz lib/lexer.wasm -o lib/lexer.wasm

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ WASM_CC := ../wasi-sdk-12.0/bin/clang
 WASM_CFLAGS := --sysroot=../wasi-sdk-12.0/share/wasi-sysroot
 WASM_LDFLAGS := -nostartfiles
 
+WASM2WAT := ../wabt/bin/wasm2wat
+WASM_OPT := ../binaryen/bin/wasm-opt
+
 # These are project-specific and are expected to be kept intact
 WASM_EXTRA_CFLAGS := -I include-wasm/ -Wno-logical-op-parentheses -Wno-parentheses -Oz
 WASM_EXTRA_LDFLAGS := -Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all
@@ -10,8 +13,8 @@ WASM_EXTRA_LDFLAGS += -Wl,--export=__heap_base,--export=parseCJS,--export=sa
 WASM_EXTRA_LDFLAGS += -Wl,--export=e,--export=re,--export=es,--export=ee
 WASM_EXTRA_LDFLAGS += -Wl,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue
 
-lslib/lexer.wat: lib/lexer.wasm
-	../wabt/bin/wasm2wat lib/lexer.wasm -o lib/lexer.wat
+lib/lexer.wat: lib/lexer.wasm
+	$(WASM2WAT) lib/lexer.wasm -o lib/lexer.wat
 
 lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c
 	@mkdir -p lib
@@ -20,7 +23,7 @@ lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c
 		$(WASM_LDFLAGS) $(WASM_EXTRA_LDFLAGS)
 
 optimize: lib/lexer.wasm
-	../binaryen/bin/wasm-opt -Oz lib/lexer.wasm -o lib/lexer.wasm
+	$(WASM_OPT) -Oz lib/lexer.wasm -o lib/lexer.wasm
 
 clean:
 	rm lib/*


### PR DESCRIPTION
When packaging for linux distribution (in my case usually Fedora and derivatives), there's usually a policy of not including any pre-build binary blobs. Compiled WebAssembly counts as a binary blob, so I need to rebuild it when packaging. This is my attempt at making my life easier when doing this :)

---

From all of the proposed commits, the first one is the most important. It re-factors the WASM compilation recipe to use variables to keep the various compilation flags; their names mirror default make variables used to compile C code.
I tried to separate the flags into system-specific ones (i.e. which compiler to use, where the WASI sysroot is, etc.) and project specific ones. This should allow me to invoke make as follows and get it to produce the WASM bits:

```sh
$ make WASM_CC=clang WASM_CFLAGS='--target=wasm32-wasi --sysroot=/usr/wasm32-wasi' WASM_LDFLAGS='-nostartfiles -nodefaultlibs -lc' lib/lexer.wasm
clang --target=wasm32-wasi --sysroot=/usr/wasm32-wasi -I include-wasm/ -Wno-logical-op-parentheses -Wno-parentheses -Oz \
	src/lexer.c -o lib/lexer.wasm \
	-nostartfiles -nodefaultlibs -lc -Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all -Wl,--export=__heap_base,--export=parseCJS,--export=sa -Wl,--export=e,--export=re,--export=es,--export=ee -Wl,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue
```

Note that if you just invoke `make`, it should still works as before the change.

---

The other commits are optional; in essence, it is a refactor of the rest of the makefile to be in line with the new way the `lib/lexer.wasm` recipe is written.

Let me know what you think.