### PR TITLE
tests: fix loading wasm when targeting external deps

### DIFF
--- a/build.js
+++ b/build.js
@@ -37,7 +37,7 @@ if (EXTERNAL_PATH) {
 let lazy;
 async function init () {
   if (!lazy) {
-    lazy = await import(require('node:url').pathToFileURL(require('node:module').createRequire('${path.join(EXTERNAL_PATH, 'dist/lexer.js')}').resolve('./lexer.mjs')));
+    lazy = await import(require('node:url').pathToFileURL(require('node:module').createRequire('${EXTERNAL_PATH}/dist/lexer.js').resolve('./lexer.mjs')));
   }
   module.exports = lazy;
   return lazy.init();

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -91,7 +91,12 @@ function copyLE (src, outBuf16) {
 }
 
 const loadWasm = (typeof EXTERNAL_PATH === "string" && (async () => {
-  return (await import('node:fs/promises')).readFile(EXTERNAL_PATH);
+  return (await import("node:fs/promises"))
+    .readFile(
+      (await import("node:url")).fileURLToPath(
+        import.meta.resolve("../lib/lexer.wasm")
+      )
+  );
 })) || (async () => {
   const binary = WASM_BINARY
   if (typeof window !== "undefined" && typeof atob === "function") {


### PR DESCRIPTION
- **tests: fix loading wasm when targeting external deps**
- **Revert "fix: cannot resolve path when build with EXTERNAL_PATH"**

Follow up of #91 and #93.
