### PR TITLE
feat: add initSync() to initialize WASM synchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ When using the ESM version, Wasm is supported instead:
 
 ```js
 import { parse, init } from 'cjs-module-lexer';
-// init needs to be called and waited upon
+// init() needs to be called and waited upon, or use initSync() to compile
+// Wasm blockingly and synchronously.
 await init();
 const { exports, reexports } = parse(source);
 ```

--- a/lexer.d.ts
+++ b/lexer.d.ts
@@ -5,3 +5,4 @@ export interface Exports {
 
 export declare function parse(source: string, name?: string): Exports;
 export declare function init(): Promise<void>;
+export declare function initSync(): void;

--- a/lexer.js
+++ b/lexer.js
@@ -1439,4 +1439,5 @@ function isExpressionTerminator (curPos) {
 const initPromise = Promise.resolve();
 
 module.exports.init = () => initPromise;
+module.exports.initSync = () => {};
 module.exports.parse = parseCJS;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "test-js": "mocha -b -u tdd test/*.js",
     "test-wasm": "cross-env WASM=1 mocha -b -u tdd test/*.js",
-    "test": "npm run test-wasm && npm run test-js",
+    "test-wasm-sync": "cross-env WASM_SYNC=1 mocha -b -u tdd test/*.js",
+    "test": "npm run test-wasm && npm run test-wasm-sync && npm run test-js",
     "bench": "node --expose-gc bench/index.mjs",
     "build": "node build.js ; babel dist/lexer.mjs -o dist/lexer.js ; terser dist/lexer.js -o dist/lexer.js",
     "build-wasm": "make lib/lexer.wasm && node build.js",

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -7,6 +7,10 @@ async function loadParser () {
     const m = await import('../dist/lexer.mjs');
     await m.init();
     parse = m.parse;
+  } else if (process.env.WASM_SYNC) {
+    const m = require('../dist/lexer.js');
+    m.initSync();
+    parse = m.parse;
   }
   else {
     parse = require('../lexer.js').parse;

--- a/test/integration.js
+++ b/test/integration.js
@@ -8,6 +8,10 @@ async function loadParser () {
     const m = await import('../dist/lexer.mjs');
     await m.init();
     parse = m.parse;
+  } else if (process.env.WASM_SYNC) {
+    const m = require('../dist/lexer.js');
+    m.initSync();
+    parse = m.parse;
   }
   else {
     parse = require('../lexer.js').parse;
@@ -31,7 +35,7 @@ suite('Samples', () => {
   const selfSource = fs.readFileSync(process.cwd() + '/lexer.js').toString();
   test('Self test', async () => {
     const { exports } = parse(selfSource);
-    assert.deepStrictEqual(exports, ['init', 'parse']);
+    assert.deepStrictEqual(exports, ['init', 'initSync', 'parse']);
   });
 
   files.forEach(({ file, code }) => {


### PR DESCRIPTION
This uses the synchronous WebAssembly APIs to compile the WASM part synchronously, which allows users to initialize the library and parse synchronously with WASM without having to resort to the JS version. This would be useful for Node.js core to use the WASM version in paths that require synchronous initialization (it currently always uses the JS version for that).