### PR TITLE
rework browser handling for buffer decoding

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -92,9 +92,9 @@ function copyLE (src, outBuf16) {
 
 function getWasmBytes() {
   const binary = 'WASM_BINARY';  // This string will be replaced by build.js.
-  if ((typeof window !== 'undefined' || typeof self !== 'undefined') && typeof atob === 'function')
-    return Uint8Array.from(atob(binary), x => x.charCodeAt(0));
-  return Buffer.from(binary, 'base64');
+  if (typeof Buffer !== 'undefined')
+    return Buffer.from(binary, 'base64');
+  return Uint8Array.from(atob(binary), x => x.charCodeAt(0));
 }
 
 let initPromise;


### PR DESCRIPTION
This reworks the environment handling in https://github.com/nodejs/cjs-module-lexer/pull/103 to try to use the faster `Buffer` path across browser platforms when possible.