### PR TITLE
fix: restore configuration through env variables

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,10 +1,21 @@
+# These flags depend on the system and may be overridden
+WASM_CC := clang
+WASM_CFLAGS := --sysroot=/usr/share/wasi-sysroot
+WASM_LDFLAGS := -nostartfiles
+
+# These are project-specific and are expected to be kept intact
+WASM_TARGET := -target wasm32-unknown-wasi
+WASM_EXTRA_CFLAGS := -I include-wasm/ -Wno-logical-op-parentheses -Wno-parentheses -Oz
+WASM_EXTRA_LDFLAGS := -Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all
+WASM_EXTRA_LDFLAGS += -Wl,--export=__heap_base,--export=parseCJS,--export=sa
+WASM_EXTRA_LDFLAGS += -Wl,--export=e,--export=re,--export=es,--export=ee
+WASM_EXTRA_LDFLAGS += -Wl,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue
+
 lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c
 	@mkdir -p lib
-	clang --sysroot=/usr/share/wasi-sysroot -target wasm32-unknown-wasi src/lexer.c -I include-wasm -o lib/lexer.wasm -nostartfiles \
-	-Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all,--export=__heap_base,\
-	--export=parseCJS,--export=sa,--export=e,--export=re,--export=es,--export=ee,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue \
-	-Wno-logical-op-parentheses -Wno-parentheses \
-	-Oz
+	$(WASM_CC) $(WASM_CFLAGS) $(WASM_TARGET) $(WASM_EXTRA_CFLAGS) \
+        src/lexer.c -o lib/lexer.wasm \
+        $(WASM_LDFLAGS) $(WASM_EXTRA_LDFLAGS)
 
 optimize: lib/lexer.wasm
 	${WASM_OPT} -Oz lib/lexer.wasm -o lib/lexer.wasm


### PR DESCRIPTION
My recent changes had removed the ability to configure what options where used to build through environment variables.

This PR restores those environment variables so they can be used as before.